### PR TITLE
ui(products): tabs on product detail + sku modal

### DIFF
--- a/app/admin/products/[id]/ProductDetailsForm.tsx
+++ b/app/admin/products/[id]/ProductDetailsForm.tsx
@@ -1,0 +1,107 @@
+import { updateProductAction } from "./actions";
+import styles from "../../_styles/adminPrimitives.module.css";
+
+type CategoryOption = {
+  id: string;
+  name: string;
+};
+
+type ProductDetailsFormProps = {
+  product: {
+    id: string;
+    name: string;
+    categoryId: string;
+    descriptionLong: string | null;
+    leadTime: number | null;
+    isActive: boolean;
+    isPublicHidden: boolean;
+    sobConsulta: boolean;
+  };
+  categories: CategoryOption[];
+  errorMessage?: string;
+};
+
+export default function ProductDetailsForm({
+  product,
+  categories,
+  errorMessage,
+}: ProductDetailsFormProps) {
+  return (
+    <section className={styles.panel}>
+      <div className={styles.panelHeader}>
+        <h2>Editar produto</h2>
+      </div>
+      <div className={styles.panelBody}>
+        {errorMessage ? (
+          <p className={styles.textError}>{errorMessage}</p>
+        ) : null}
+        <form action={updateProductAction} className={styles.formGrid}>
+          <input type="hidden" name="id" value={product.id} />
+          <input
+            name="name"
+            defaultValue={product.name}
+            required
+            className={styles.control}
+          />
+          <select
+            name="categoryId"
+            defaultValue={product.categoryId}
+            required
+            className={styles.control}
+          >
+            {categories.map((category) => (
+              <option key={category.id} value={category.id}>
+                {category.name}
+              </option>
+            ))}
+          </select>
+          <textarea
+            name="descriptionLong"
+            defaultValue={product.descriptionLong || ""}
+            placeholder="Descricao longa"
+            className={`${styles.control} ${styles.controlTextarea} ${styles.fieldFull}`}
+          ></textarea>
+          <input
+            type="number"
+            name="leadTime"
+            defaultValue={product.leadTime ?? ""}
+            placeholder="Lead time (horas)"
+            min="0"
+            step="1"
+            className={styles.control}
+          />
+          <label className={styles.choiceRow}>
+            <input
+              type="checkbox"
+              name="isActive"
+              defaultChecked={product.isActive}
+            />
+            <span className={styles.choiceLabel}>Ativo</span>
+          </label>
+          <label className={styles.choiceRow}>
+            <input
+              type="checkbox"
+              name="isPublicHidden"
+              defaultChecked={product.isPublicHidden}
+            />
+            <span className={styles.choiceLabel}>Ocultar do publico</span>
+          </label>
+          <label className={styles.choiceRow}>
+            <input
+              type="checkbox"
+              name="sobConsulta"
+              defaultChecked={product.sobConsulta}
+            />
+            <span className={styles.choiceLabel}>Sob consulta</span>
+          </label>
+          <button
+            type="submit"
+            className={`${styles.button} ${styles.buttonPrimary}`}
+          >
+            Salvar produto
+          </button>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/app/admin/products/[id]/ProductImagesForm.tsx
+++ b/app/admin/products/[id]/ProductImagesForm.tsx
@@ -1,0 +1,47 @@
+import { updateProductImagesAction } from "./actions";
+import styles from "../../_styles/adminPrimitives.module.css";
+
+type ProductImagesFormProps = {
+  productId: string;
+  imageMainUrl: string | null;
+  imageExtraUrls: string;
+};
+
+export default function ProductImagesForm({
+  productId,
+  imageMainUrl,
+  imageExtraUrls,
+}: ProductImagesFormProps) {
+  return (
+    <section className={styles.panel}>
+      <div className={styles.panelHeader}>
+        <h2>Imagens</h2>
+      </div>
+      <div className={styles.panelBody}>
+        <form action={updateProductImagesAction} className={styles.formSection}>
+          <input type="hidden" name="id" value={productId} />
+          <input
+            name="imageMainUrl"
+            defaultValue={imageMainUrl || ""}
+            placeholder="URL da imagem principal"
+            className={styles.control}
+          />
+          <textarea
+            name="imageExtraUrls"
+            defaultValue={imageExtraUrls}
+            placeholder="URLs extras (uma por linha)"
+            className={`${styles.control} ${styles.controlTextarea}`}
+          ></textarea>
+          <div className={styles.panelFooter}>
+            <button
+              type="submit"
+              className={`${styles.button} ${styles.buttonPrimary}`}
+            >
+              Salvar imagens
+            </button>
+          </div>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/app/admin/products/[id]/ProductSkusSection.client.tsx
+++ b/app/admin/products/[id]/ProductSkusSection.client.tsx
@@ -1,0 +1,487 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useFormStatus } from "react-dom";
+import styles from "../../_styles/adminPrimitives.module.css";
+import detailStyles from "./productDetail.module.css";
+
+type SkuView = {
+  id: string;
+  displayName: string;
+  sizeText: string;
+  flavorText: string;
+  isFrozen: boolean;
+  unitType: string;
+  unitLabel: string;
+  quantityStep: number;
+  minQty: number;
+  priceCurrent: number;
+  cost: number | null;
+  isActive: boolean;
+  sobConsultaOverride: boolean | null;
+  tags: string[];
+};
+
+type SkuFormMode = "new" | "edit";
+
+type ProductSkusSectionProps = {
+  productId: string;
+  productSobConsulta: boolean;
+  skus: SkuView[];
+  createSkuAction: (formData: FormData) => void;
+  updateSkuAction: (formData: FormData) => void;
+  duplicateSkuAction: (formData: FormData) => void;
+  initialMode?: SkuFormMode;
+  initialSkuId?: string | null;
+  skuErrorMessage?: string;
+};
+
+const unitTypeOptions = [
+  { value: "UNIDADE", label: "UNIDADE" },
+  { value: "CENTO", label: "CENTO" },
+  { value: "KG", label: "KG" },
+];
+
+function SkuFormActions({ onCancel }: { onCancel: () => void }) {
+  const { pending } = useFormStatus();
+  return (
+    <div className={detailStyles.modalFooter}>
+      <button
+        type="button"
+        className={`${styles.button} ${styles.buttonGhost}`}
+        disabled={pending}
+        onClick={onCancel}
+      >
+        Cancelar
+      </button>
+      <button
+        type="submit"
+        className={`${styles.button} ${styles.buttonPrimary}`}
+        disabled={pending}
+      >
+        {pending ? "Salvando..." : "Salvar"}
+      </button>
+    </div>
+  );
+}
+
+export default function ProductSkusSection({
+  productId,
+  productSobConsulta,
+  skus,
+  createSkuAction,
+  updateSkuAction,
+  duplicateSkuAction,
+  initialMode,
+  initialSkuId,
+  skuErrorMessage,
+}: ProductSkusSectionProps) {
+  const initialSku = useMemo(
+    () => (initialSkuId ? skus.find((sku) => sku.id === initialSkuId) : null),
+    [initialSkuId, skus]
+  );
+  const shouldOpenInitial = Boolean(initialMode || skuErrorMessage);
+  const [modalOpen, setModalOpen] = useState(shouldOpenInitial);
+  const [mode, setMode] = useState<SkuFormMode>(initialMode ?? "new");
+  const [activeSkuId, setActiveSkuId] = useState<string | null>(
+    initialSku?.id ?? null
+  );
+  const [modalError, setModalError] = useState(skuErrorMessage ?? "");
+
+  const activeSku = useMemo(
+    () => skus.find((sku) => sku.id === activeSkuId) ?? null,
+    [activeSkuId, skus]
+  );
+
+  useEffect(() => {
+    if (!modalOpen) return;
+    function handleKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setModalOpen(false);
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [modalOpen]);
+
+  function openNew() {
+    setMode("new");
+    setActiveSkuId(null);
+    setModalError("");
+    setModalOpen(true);
+  }
+
+  function openEdit(id: string) {
+    setMode("edit");
+    setActiveSkuId(id);
+    setModalError("");
+    setModalOpen(true);
+  }
+
+  function closeModal() {
+    setModalOpen(false);
+  }
+
+  function renderSobConsultaLabel(sku: SkuView) {
+    if (sku.sobConsultaOverride === true) return "SIM";
+    if (sku.sobConsultaOverride === false) return "NAO";
+    return productSobConsulta ? "SIM" : "NAO";
+  }
+
+  const modalSku = mode === "edit" ? activeSku : null;
+  const modalTitle = mode === "edit" ? "Editar SKU" : "Novo SKU";
+
+  return (
+    <section className={styles.panel}>
+      <div className={styles.panelHeader}>
+        <h2>SKUs</h2>
+        <button
+          type="button"
+          onClick={openNew}
+          className={`${styles.button} ${styles.buttonPrimary}`}
+        >
+          + Novo SKU
+        </button>
+      </div>
+      <div className={styles.panelBody}>
+        {skus.length === 0 ? (
+          <div className={styles.emptyState}>Nenhum SKU cadastrado.</div>
+        ) : (
+          <div className={styles.tableWrap}>
+            <table className={styles.table}>
+              <thead>
+                <tr>
+                  <th>SKU</th>
+                  <th>Unidade</th>
+                  <th className={styles.tableNumeric}>Preco</th>
+                  <th>Status</th>
+                  <th>Sob consulta</th>
+                  <th className={styles.tableActions}>Acoes</th>
+                </tr>
+              </thead>
+              <tbody>
+                {skus.map((sku) => {
+                  const nextActive = !sku.isActive;
+                  const sobValue =
+                    sku.sobConsultaOverride === true
+                      ? "true"
+                      : sku.sobConsultaOverride === false
+                      ? "false"
+                      : "inherit";
+                  return (
+                    <tr key={sku.id}>
+                      <td>
+                        <div className={detailStyles.skuMeta}>
+                          <strong>{sku.displayName}</strong>
+                          <span className={detailStyles.skuSubline}>
+                            {sku.sizeText}
+                            {sku.flavorText ? ` · ${sku.flavorText}` : ""}
+                          </span>
+                        </div>
+                      </td>
+                      <td>
+                        {sku.unitType} ({sku.unitLabel})
+                      </td>
+                      <td className={styles.tableNumeric}>
+                        R$ {sku.priceCurrent.toFixed(2)}
+                      </td>
+                      <td>{sku.isActive ? "ATIVO" : "INATIVO"}</td>
+                      <td>{renderSobConsultaLabel(sku)}</td>
+                      <td className={styles.tableActions}>
+                        <div className={styles.clusterSm}>
+                          <button
+                            type="button"
+                            onClick={() => openEdit(sku.id)}
+                            className={`${styles.button} ${styles.buttonGhost} ${styles.buttonSm}`}
+                          >
+                            Editar
+                          </button>
+                          <form action={duplicateSkuAction}>
+                            <input
+                              type="hidden"
+                              name="productId"
+                              value={productId}
+                            />
+                            <input type="hidden" name="skuId" value={sku.id} />
+                            <button
+                              type="submit"
+                              className={`${styles.button} ${styles.buttonGhost} ${styles.buttonSm}`}
+                            >
+                              Duplicar
+                            </button>
+                          </form>
+                          <form action={updateSkuAction}>
+                            <input
+                              type="hidden"
+                              name="productId"
+                              value={productId}
+                            />
+                            <input type="hidden" name="skuId" value={sku.id} />
+                            <input
+                              type="hidden"
+                              name="displayName"
+                              value={sku.displayName}
+                            />
+                            <input
+                              type="hidden"
+                              name="sizeText"
+                              value={sku.sizeText}
+                            />
+                            <input
+                              type="hidden"
+                              name="flavorText"
+                              value={sku.flavorText}
+                            />
+                            {sku.isFrozen ? (
+                              <input
+                                type="hidden"
+                                name="isFrozen"
+                                value="on"
+                              />
+                            ) : null}
+                            <input
+                              type="hidden"
+                              name="unitType"
+                              value={sku.unitType}
+                            />
+                            <input
+                              type="hidden"
+                              name="unitLabel"
+                              value={sku.unitLabel}
+                            />
+                            <input
+                              type="hidden"
+                              name="quantityStep"
+                              value={String(sku.quantityStep)}
+                            />
+                            <input
+                              type="hidden"
+                              name="minQty"
+                              value={String(sku.minQty)}
+                            />
+                            <input
+                              type="hidden"
+                              name="priceCurrent"
+                              value={String(sku.priceCurrent)}
+                            />
+                            <input
+                              type="hidden"
+                              name="cost"
+                              value={sku.cost !== null ? String(sku.cost) : ""}
+                            />
+                            <input
+                              type="hidden"
+                              name="tags"
+                              value={sku.tags.join(", ")}
+                            />
+                            <input
+                              type="hidden"
+                              name="sobConsultaOverride"
+                              value={sobValue}
+                            />
+                            {nextActive ? (
+                              <input
+                                type="hidden"
+                                name="isActive"
+                                value="on"
+                              />
+                            ) : null}
+                            <button
+                              type="submit"
+                              className={`${styles.button} ${styles.buttonGhost} ${styles.buttonSm}`}
+                            >
+                              {nextActive ? "Ativar" : "Desativar"}
+                            </button>
+                          </form>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {modalOpen ? (
+        <div
+          className={detailStyles.modalOverlay}
+          onClick={() => setModalOpen(false)}
+        >
+          <div
+            className={detailStyles.modalCard}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className={detailStyles.modalHeader}>
+              <h3 className={detailStyles.modalTitle}>{modalTitle}</h3>
+              <button
+                type="button"
+                onClick={closeModal}
+                className={`${styles.button} ${styles.buttonGhost} ${styles.buttonSm}`}
+              >
+                Fechar
+              </button>
+            </div>
+
+            {modalError ? (
+              <div className={`${styles.notice} ${styles.noticeError}`}>
+                {modalError}
+              </div>
+            ) : null}
+
+            <form
+              action={mode === "edit" ? updateSkuAction : createSkuAction}
+              className={styles.formGrid}
+            >
+              <input type="hidden" name="productId" value={productId} />
+              {mode === "edit" && modalSku ? (
+                <input type="hidden" name="skuId" value={modalSku.id} />
+              ) : null}
+              {!modalSku && mode === "edit" ? (
+                <p className={styles.textError}>SKU nao encontrado.</p>
+              ) : null}
+              <input
+                name="displayName"
+                placeholder="Nome exibido"
+                required
+                defaultValue={modalSku?.displayName ?? ""}
+                className={`${styles.control} ${styles.fieldFull}`}
+              />
+              <input
+                name="sizeText"
+                placeholder="Tamanho"
+                required
+                defaultValue={modalSku?.sizeText ?? ""}
+                className={styles.control}
+              />
+              <input
+                name="flavorText"
+                placeholder="Sabor (opcional)"
+                defaultValue={modalSku?.flavorText ?? ""}
+                className={styles.control}
+              />
+              <label className={styles.choiceRow}>
+                <input
+                  type="checkbox"
+                  name="isFrozen"
+                  defaultChecked={modalSku?.isFrozen ?? false}
+                />
+                <span className={styles.choiceLabel}>Congelado</span>
+              </label>
+              <label className={styles.field}>
+                Tipo de venda
+                <select
+                  name="unitType"
+                  defaultValue={modalSku?.unitType ?? "UNIDADE"}
+                  className={styles.control}
+                >
+                  {unitTypeOptions.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <input
+                name="unitLabel"
+                placeholder="un/cento/kg/kit"
+                required
+                defaultValue={modalSku?.unitLabel ?? ""}
+                className={styles.control}
+              />
+              <label className={styles.field}>
+                Passo de quantidade
+                <input
+                  type="number"
+                  name="quantityStep"
+                  step="0.1"
+                  required
+                  defaultValue={
+                    modalSku ? String(modalSku.quantityStep) : ""
+                  }
+                  className={styles.control}
+                />
+              </label>
+              <label className={styles.field}>
+                Minimo
+                <input
+                  type="number"
+                  name="minQty"
+                  step="0.1"
+                  required
+                  defaultValue={modalSku ? String(modalSku.minQty) : ""}
+                  className={styles.control}
+                />
+              </label>
+              <label className={styles.field}>
+                Preco atual
+                <input
+                  type="number"
+                  name="priceCurrent"
+                  step="0.01"
+                  required
+                  defaultValue={
+                    modalSku ? String(modalSku.priceCurrent) : ""
+                  }
+                  className={styles.control}
+                />
+              </label>
+              <label className={styles.field}>
+                Custo (opcional)
+                <input
+                  type="number"
+                  name="cost"
+                  step="0.01"
+                  defaultValue={
+                    modalSku && modalSku.cost !== null
+                      ? String(modalSku.cost)
+                      : ""
+                  }
+                  className={styles.control}
+                />
+              </label>
+              <label className={styles.field}>
+                Tags (separadas por virgula)
+                <input
+                  name="tags"
+                  placeholder="salgado, festa"
+                  defaultValue={modalSku?.tags.join(", ") ?? ""}
+                  className={styles.control}
+                />
+              </label>
+              <label className={styles.field}>
+                Sob consulta
+                <select
+                  name="sobConsultaOverride"
+                  defaultValue={
+                    modalSku?.sobConsultaOverride === true
+                      ? "true"
+                      : modalSku?.sobConsultaOverride === false
+                      ? "false"
+                      : "inherit"
+                  }
+                  className={styles.control}
+                >
+                  <option value="inherit">Herdar do produto</option>
+                  <option value="true">Forcar sob consulta</option>
+                  <option value="false">Forcar nao</option>
+                </select>
+              </label>
+              <label className={styles.choiceRow}>
+                <input
+                  type="checkbox"
+                  name="isActive"
+                  defaultChecked={modalSku?.isActive ?? true}
+                />
+                <span className={styles.choiceLabel}>Ativo</span>
+              </label>
+
+              <SkuFormActions onCancel={closeModal} />
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/app/admin/products/[id]/ProductTabs.tsx
+++ b/app/admin/products/[id]/ProductTabs.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import detailStyles from "./productDetail.module.css";
+
+type TabId = "details" | "skus" | "images";
+
+type TabDefinition = {
+  id: TabId;
+  label: string;
+};
+
+const TABS: TabDefinition[] = [
+  { id: "details", label: "Detalhes" },
+  { id: "skus", label: "SKUs" },
+  { id: "images", label: "Imagens" },
+];
+
+export default function ProductTabs({
+  activeTab,
+  productId,
+}: {
+  activeTab: TabId;
+  productId: string;
+}) {
+  return (
+    <div className={detailStyles.tabs}>
+      <div className={detailStyles.tabList} role="tablist">
+        {TABS.map((tab) => {
+          const isActive = activeTab === tab.id;
+          return (
+            <Link
+              key={tab.id}
+              href={`/admin/products/${productId}?tab=${tab.id}`}
+              role="tab"
+              aria-selected={isActive}
+              aria-current={isActive ? "page" : undefined}
+              className={`${detailStyles.tabButton} ${
+                isActive ? detailStyles.tabButtonActive : ""
+              }`}
+            >
+              {tab.label}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/products/[id]/actions.ts
+++ b/app/admin/products/[id]/actions.ts
@@ -28,6 +28,13 @@ function parseTags(value: FormDataEntryValue | null) {
     .filter(Boolean);
 }
 
+function parseLines(value: FormDataEntryValue | null) {
+  return String(value ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
 function ensureInteger(value: number | null) {
   if (value === null || !Number.isInteger(value)) return null;
   return value;
@@ -43,14 +50,17 @@ export async function updateProductAction(formData: FormData) {
   const isActive = parseBool(formData.get("isActive"));
   const isPublicHidden = parseBool(formData.get("isPublicHidden"));
   const sobConsulta = parseBool(formData.get("sobConsulta"));
-  const imageMainUrl = parseText(formData.get("imageMainUrl"));
-  const imageExtraUrls = String(formData.get("imageExtraUrls") ?? "")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
+  const hasImageMainUrl = formData.has("imageMainUrl");
+  const hasImageExtraUrls = formData.has("imageExtraUrls");
+  const imageMainUrl = hasImageMainUrl
+    ? parseText(formData.get("imageMainUrl"))
+    : "";
+  const imageExtraUrls = hasImageExtraUrls
+    ? parseLines(formData.get("imageExtraUrls"))
+    : [];
 
   if (!id || !name || !categoryId) {
-    redirect(`/admin/products/${id}?error=campos`);
+    redirect(`/admin/products/${id}?tab=details&error=campos`);
   }
 
   await prisma.$transaction(async (tx) => {
@@ -64,23 +74,25 @@ export async function updateProductAction(formData: FormData) {
         isActive,
         isPublicHidden,
         sobConsulta,
-        imageMainUrl: imageMainUrl || null,
+        ...(hasImageMainUrl ? { imageMainUrl: imageMainUrl || null } : {}),
       },
     });
 
-    await tx.productImage.deleteMany({ where: { productId: id } });
-    if (imageExtraUrls.length) {
-      await tx.productImage.createMany({
-        data: imageExtraUrls.map((url, index) => ({
-          productId: id,
-          url,
-          sortOrder: index,
-        })),
-      });
+    if (hasImageExtraUrls) {
+      await tx.productImage.deleteMany({ where: { productId: id } });
+      if (imageExtraUrls.length) {
+        await tx.productImage.createMany({
+          data: imageExtraUrls.map((url, index) => ({
+            productId: id,
+            url,
+            sortOrder: index,
+          })),
+        });
+      }
     }
   });
 
-  redirect(`/admin/products/${id}`);
+  redirect(`/admin/products/${id}?tab=details`);
 }
 
 export async function createSkuAction(formData: FormData) {
@@ -101,17 +113,17 @@ export async function createSkuAction(formData: FormData) {
   const tags = parseTags(formData.get("tags"));
 
   if (!productId || !displayName || !sizeText || !quantityStep || !priceCurrent) {
-    redirect(`/admin/products/${productId}?error=sku_campos`);
+    redirect(`/admin/products/${productId}?tab=skus&error=sku_campos&skuMode=new`);
   }
 
   if (unitType === "KG" && unitLabel !== "kg") {
-    redirect(`/admin/products/${productId}?error=sku_unit`);
+    redirect(`/admin/products/${productId}?tab=skus&error=sku_unit&skuMode=new`);
   }
   if (unitType === "CENTO" && unitLabel !== "cento") {
-    redirect(`/admin/products/${productId}?error=sku_unit`);
+    redirect(`/admin/products/${productId}?tab=skus&error=sku_unit&skuMode=new`);
   }
   if (unitType === "UNIDADE" && (unitLabel === "kg" || unitLabel === "cento")) {
-    redirect(`/admin/products/${productId}?error=sku_unit`);
+    redirect(`/admin/products/${productId}?tab=skus&error=sku_unit&skuMode=new`);
   }
 
   const normalizedQtyStep =
@@ -120,7 +132,9 @@ export async function createSkuAction(formData: FormData) {
     unitType === "KG" ? minQty ?? 1 : ensureInteger(minQty ?? 1);
 
   if (!normalizedQtyStep || !normalizedMinQty) {
-    redirect(`/admin/products/${productId}?error=sku_quantidade`);
+    redirect(
+      `/admin/products/${productId}?tab=skus&error=sku_quantidade&skuMode=new`
+    );
   }
 
   const sobConsultaOverride =
@@ -155,7 +169,7 @@ export async function createSkuAction(formData: FormData) {
     }
   });
 
-  redirect(`/admin/products/${productId}`);
+  redirect(`/admin/products/${productId}?tab=skus`);
 }
 
 export async function updateSkuAction(formData: FormData) {
@@ -177,17 +191,25 @@ export async function updateSkuAction(formData: FormData) {
   const tags = parseTags(formData.get("tags"));
 
   if (!productId || !skuId || !displayName || !sizeText || !quantityStep || !priceCurrent) {
-    redirect(`/admin/products/${productId}?error=sku_campos`);
+    redirect(
+      `/admin/products/${productId}?tab=skus&error=sku_campos&skuMode=edit&skuId=${skuId}`
+    );
   }
 
   if (unitType === "KG" && unitLabel !== "kg") {
-    redirect(`/admin/products/${productId}?error=sku_unit`);
+    redirect(
+      `/admin/products/${productId}?tab=skus&error=sku_unit&skuMode=edit&skuId=${skuId}`
+    );
   }
   if (unitType === "CENTO" && unitLabel !== "cento") {
-    redirect(`/admin/products/${productId}?error=sku_unit`);
+    redirect(
+      `/admin/products/${productId}?tab=skus&error=sku_unit&skuMode=edit&skuId=${skuId}`
+    );
   }
   if (unitType === "UNIDADE" && (unitLabel === "kg" || unitLabel === "cento")) {
-    redirect(`/admin/products/${productId}?error=sku_unit`);
+    redirect(
+      `/admin/products/${productId}?tab=skus&error=sku_unit&skuMode=edit&skuId=${skuId}`
+    );
   }
 
   const normalizedQtyStep =
@@ -196,7 +218,9 @@ export async function updateSkuAction(formData: FormData) {
     unitType === "KG" ? minQty ?? 1 : ensureInteger(minQty ?? 1);
 
   if (!normalizedQtyStep || !normalizedMinQty) {
-    redirect(`/admin/products/${productId}?error=sku_quantidade`);
+    redirect(
+      `/admin/products/${productId}?tab=skus&error=sku_quantidade&skuMode=edit&skuId=${skuId}`
+    );
   }
 
   const sobConsultaOverride =
@@ -232,7 +256,7 @@ export async function updateSkuAction(formData: FormData) {
     }
   });
 
-  redirect(`/admin/products/${productId}`);
+  redirect(`/admin/products/${productId}?tab=skus`);
 }
 
 export async function duplicateSkuAction(formData: FormData) {
@@ -240,7 +264,7 @@ export async function duplicateSkuAction(formData: FormData) {
   const productId = parseText(formData.get("productId"));
   const skuId = parseText(formData.get("skuId"));
   if (!productId || !skuId) {
-    redirect(`/admin/products/${productId}`);
+    redirect(`/admin/products/${productId}?tab=skus`);
   }
 
   await prisma.$transaction(async (tx) => {
@@ -249,7 +273,7 @@ export async function duplicateSkuAction(formData: FormData) {
       include: { tags: true },
     });
     if (!sku) {
-      redirect(`/admin/products/${productId}`);
+      redirect(`/admin/products/${productId}?tab=skus`);
     }
 
     const suffix = new Date().toISOString().slice(11, 19).replace(/:/g, "");
@@ -283,5 +307,38 @@ export async function duplicateSkuAction(formData: FormData) {
     }
   });
 
-  redirect(`/admin/products/${productId}`);
+  redirect(`/admin/products/${productId}?tab=skus`);
+}
+
+export async function updateProductImagesAction(formData: FormData) {
+  await requireAdminSession();
+  const id = parseText(formData.get("id"));
+  const imageMainUrl = parseText(formData.get("imageMainUrl"));
+  const imageExtraUrls = parseLines(formData.get("imageExtraUrls"));
+
+  if (!id) {
+    redirect(`/admin/products/${id}?tab=images`);
+  }
+
+  await prisma.$transaction(async (tx) => {
+    await tx.product.update({
+      where: { id },
+      data: {
+        imageMainUrl: imageMainUrl || null,
+      },
+    });
+
+    await tx.productImage.deleteMany({ where: { productId: id } });
+    if (imageExtraUrls.length) {
+      await tx.productImage.createMany({
+        data: imageExtraUrls.map((url, index) => ({
+          productId: id,
+          url,
+          sortOrder: index,
+        })),
+      });
+    }
+  });
+
+  redirect(`/admin/products/${id}?tab=images`);
 }

--- a/app/admin/products/[id]/page.tsx
+++ b/app/admin/products/[id]/page.tsx
@@ -3,20 +3,20 @@ import { prisma } from "@/lib/prisma";
 import {
   createSkuAction,
   duplicateSkuAction,
-  updateProductAction,
   updateSkuAction,
 } from "./actions";
+import ProductTabs from "./ProductTabs";
+import ProductDetailsForm from "./ProductDetailsForm";
+import ProductImagesForm from "./ProductImagesForm";
+import ProductSkusSection from "./ProductSkusSection.client";
 import styles from "../../_styles/adminPrimitives.module.css";
 
 type ProductSearchParams = {
   error?: string;
+  tab?: string;
+  skuMode?: string;
+  skuId?: string;
 };
-
-const unitTypeOptions = [
-  { value: "UNIDADE", label: "UNIDADE" },
-  { value: "CENTO", label: "CENTO" },
-  { value: "KG", label: "KG" },
-];
 
 export default async function ProductDetailPage({
   params,
@@ -28,6 +28,10 @@ export default async function ProductDetailPage({
   const p = await Promise.resolve(params);
   const sp = await Promise.resolve(searchParams);
   const productId = p?.id;
+  const tab = sp?.tab;
+  const skuMode = sp?.skuMode;
+  const skuId = sp?.skuId;
+  const error = sp?.error;
 
   const product = await prisma.product.findUnique({
     where: { id: productId },
@@ -61,6 +65,40 @@ export default async function ProductDetailPage({
     .map((img) => img.url)
     .join("\n");
 
+  const productErrorMessage =
+    error === "campos" ? "Preencha nome e categoria para salvar." : "";
+  const skuErrorMessage =
+    error === "sku_campos"
+      ? "Preencha nome, tamanho, tipo de venda, passo, minimo e preco."
+      : error === "sku_unit"
+      ? "Tipo de venda e label de unidade incoerentes."
+      : error === "sku_quantidade"
+      ? "Passo/minimo invalidos para o tipo de venda."
+      : "";
+
+  const initialTab =
+    tab === "skus" || tab === "images" || tab === "details" ? tab : "details";
+  const initialSkuMode =
+    skuMode === "edit" || skuMode === "new" ? skuMode : undefined;
+  const initialSkuId = skuId || undefined;
+
+  const skusView = product.skus.map((sku) => ({
+    id: sku.id,
+    displayName: sku.displayName,
+    sizeText: sku.sizeText,
+    flavorText: sku.flavorText || "",
+    isFrozen: sku.isFrozen,
+    unitType: sku.unitType,
+    unitLabel: sku.unitLabel,
+    quantityStep: Number(sku.quantityStep),
+    minQty: Number(sku.minQty),
+    priceCurrent: Number(sku.priceCurrent),
+    cost: sku.cost ? Number(sku.cost) : null,
+    isActive: sku.isActive,
+    sobConsultaOverride: sku.sobConsultaOverride,
+    tags: sku.tags.map((tag) => tag.name),
+  }));
+
   return (
     <main className={styles.page}>
       <div className={styles.pageHeader}>
@@ -68,439 +106,43 @@ export default async function ProductDetailPage({
         <Link href="/admin/products">Voltar</Link>
       </div>
 
-      {sp?.error === "campos" ? (
-        <p className={styles.textError}>
-          Preencha nome e categoria para salvar.
-        </p>
+      <ProductTabs activeTab={initialTab} productId={product.id} />
+      {initialTab === "details" ? (
+        <ProductDetailsForm
+          product={{
+            id: product.id,
+            name: product.name,
+            categoryId: product.categoryId,
+            descriptionLong: product.descriptionLong,
+            leadTime: product.leadTime ?? null,
+            isActive: product.isActive,
+            isPublicHidden: product.isPublicHidden,
+            sobConsulta: product.sobConsulta,
+          }}
+          categories={categories}
+          errorMessage={productErrorMessage}
+        />
       ) : null}
-      {sp?.error === "sku_campos" ? (
-        <p className={styles.textError}>
-          Preencha nome, tamanho, tipo de venda, passo, minimo e preco.
-        </p>
+      {initialTab === "skus" ? (
+        <ProductSkusSection
+          productId={product.id}
+          productSobConsulta={product.sobConsulta}
+          skus={skusView}
+          createSkuAction={createSkuAction}
+          updateSkuAction={updateSkuAction}
+          duplicateSkuAction={duplicateSkuAction}
+          initialMode={initialSkuMode}
+          initialSkuId={initialSkuId}
+          skuErrorMessage={skuErrorMessage}
+        />
       ) : null}
-      {sp?.error === "sku_unit" ? (
-        <p className={styles.textError}>
-          Tipo de venda e label de unidade incoerentes.
-        </p>
+      {initialTab === "images" ? (
+        <ProductImagesForm
+          productId={product.id}
+          imageMainUrl={product.imageMainUrl}
+          imageExtraUrls={imageExtraUrls}
+        />
       ) : null}
-      {sp?.error === "sku_quantidade" ? (
-        <p className={styles.textError}>
-          Passo/minimo invalidos para o tipo de venda.
-        </p>
-      ) : null}
-
-      <section className={styles.panel}>
-        <div className={styles.panelHeader}>
-          <h2>Editar produto</h2>
-        </div>
-        <div className={styles.panelBody}>
-          <form action={updateProductAction} className={styles.formGrid}>
-            <input type="hidden" name="id" value={product.id} />
-            <input
-              name="name"
-              defaultValue={product.name}
-              required
-              className={styles.control}
-            />
-            <select
-              name="categoryId"
-              defaultValue={product.categoryId}
-              required
-              className={styles.control}
-            >
-              {categories.map((category) => (
-                <option key={category.id} value={category.id}>
-                  {category.name}
-                </option>
-              ))}
-            </select>
-            <textarea
-              name="descriptionLong"
-              defaultValue={product.descriptionLong || ""}
-              placeholder="Descricao longa"
-              className={`${styles.control} ${styles.controlTextarea} ${styles.fieldFull}`}
-            ></textarea>
-            <input
-              type="number"
-              name="leadTime"
-              defaultValue={product.leadTime ?? ""}
-              placeholder="Lead time (horas)"
-              min="0"
-              step="1"
-              className={styles.control}
-            />
-            <label className={styles.choiceRow}>
-              <input
-                type="checkbox"
-                name="isActive"
-                defaultChecked={product.isActive}
-              />
-              <span className={styles.choiceLabel}>Ativo</span>
-            </label>
-            <label className={styles.choiceRow}>
-              <input
-                type="checkbox"
-                name="isPublicHidden"
-                defaultChecked={product.isPublicHidden}
-              />
-              <span className={styles.choiceLabel}>Ocultar do publico</span>
-            </label>
-            <label className={styles.choiceRow}>
-              <input
-                type="checkbox"
-                name="sobConsulta"
-                defaultChecked={product.sobConsulta}
-              />
-              <span className={styles.choiceLabel}>Sob consulta</span>
-            </label>
-            <input
-              name="imageMainUrl"
-              defaultValue={product.imageMainUrl || ""}
-              placeholder="URL da imagem principal"
-              className={`${styles.control} ${styles.fieldFull}`}
-            />
-            <textarea
-              name="imageExtraUrls"
-              defaultValue={imageExtraUrls}
-              placeholder="URLs extras (uma por linha)"
-              className={`${styles.control} ${styles.controlTextarea} ${styles.fieldFull}`}
-            ></textarea>
-            <button
-              type="submit"
-              className={`${styles.button} ${styles.buttonPrimary}`}
-            >
-              Salvar produto
-            </button>
-          </form>
-        </div>
-      </section>
-
-      <section className={styles.panel}>
-        <div className={styles.panelHeader}>
-          <h2>Novo SKU</h2>
-        </div>
-        <div className={styles.panelBody}>
-          <form action={createSkuAction} className={styles.formGrid}>
-            <input type="hidden" name="productId" value={product.id} />
-            <input
-              name="displayName"
-              placeholder="Nome exibido"
-              required
-              className={`${styles.control} ${styles.fieldFull}`}
-            />
-            <input
-              name="sizeText"
-              placeholder="Tamanho"
-              required
-              className={styles.control}
-            />
-            <input
-              name="flavorText"
-              placeholder="Sabor (opcional)"
-              className={styles.control}
-            />
-            <label className={styles.choiceRow}>
-              <input type="checkbox" name="isFrozen" />
-              <span className={styles.choiceLabel}>Congelado</span>
-            </label>
-            <label className={styles.field}>
-              Tipo de venda
-              <select
-                name="unitType"
-                defaultValue="UNIDADE"
-                className={styles.control}
-              >
-                {unitTypeOptions.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <input
-              name="unitLabel"
-              placeholder="un/cento/kg/kit"
-              required
-              className={styles.control}
-            />
-            <label className={styles.field}>
-              Passo de quantidade
-              <input
-                type="number"
-                name="quantityStep"
-                step="0.1"
-                required
-                className={styles.control}
-              />
-            </label>
-            <label className={styles.field}>
-              Minimo
-              <input
-                type="number"
-                name="minQty"
-                step="0.1"
-                required
-                className={styles.control}
-              />
-            </label>
-            <label className={styles.field}>
-              Preco atual
-              <input
-                type="number"
-                name="priceCurrent"
-                step="0.01"
-                required
-                className={styles.control}
-              />
-            </label>
-            <label className={styles.field}>
-              Custo (opcional)
-              <input
-                type="number"
-                name="cost"
-                step="0.01"
-                className={styles.control}
-              />
-            </label>
-            <label className={styles.field}>
-              Tags (separadas por virgula)
-              <input
-                name="tags"
-                placeholder="salgado, festa"
-                className={styles.control}
-              />
-            </label>
-            <label className={styles.field}>
-              Sob consulta
-              <select
-                name="sobConsultaOverride"
-                defaultValue="inherit"
-                className={styles.control}
-              >
-                <option value="inherit">Herdar do produto</option>
-                <option value="true">Forcar sob consulta</option>
-                <option value="false">Forcar nao</option>
-              </select>
-            </label>
-            <label className={styles.choiceRow}>
-              <input type="checkbox" name="isActive" defaultChecked />
-              <span className={styles.choiceLabel}>Ativo</span>
-            </label>
-            <button
-              type="submit"
-              className={`${styles.button} ${styles.buttonPrimary}`}
-            >
-              Criar SKU
-            </button>
-          </form>
-        </div>
-      </section>
-
-      <section className={styles.panel}>
-        <div className={styles.panelHeader}>
-          <h2>SKUs</h2>
-        </div>
-        {product.skus.length === 0 ? (
-          <div className={styles.emptyState}>Nenhum SKU cadastrado.</div>
-        ) : (
-          <div className={styles.tableWrap}>
-            <table className={styles.table}>
-              <thead>
-                <tr>
-                  <th>Nome</th>
-                  <th>Tamanho</th>
-                  <th>Tipo</th>
-                  <th>Status</th>
-                  <th>Sob consulta</th>
-                  <th className={styles.tableNumeric}>Preco</th>
-                  <th className={styles.tableActions}>Acoes</th>
-                </tr>
-              </thead>
-              <tbody>
-                {product.skus.map((sku) => (
-                  <tr key={sku.id}>
-                    <td>
-                      <form action={updateSkuAction} className={styles.stackSm}>
-                        <input
-                          type="hidden"
-                          name="productId"
-                          value={product.id}
-                        />
-                        <input type="hidden" name="skuId" value={sku.id} />
-                        <input
-                          name="displayName"
-                          defaultValue={sku.displayName}
-                          required
-                          className={styles.control}
-                        />
-                        <input
-                          name="sizeText"
-                          defaultValue={sku.sizeText}
-                          required
-                          className={styles.control}
-                        />
-                        <input
-                          name="flavorText"
-                          defaultValue={sku.flavorText || ""}
-                          placeholder="Sabor"
-                          className={styles.control}
-                        />
-                        <label className={styles.choiceRow}>
-                          <input
-                            type="checkbox"
-                            name="isFrozen"
-                            defaultChecked={sku.isFrozen}
-                          />
-                          <span className={styles.choiceLabel}>Congelado</span>
-                        </label>
-                        <label className={styles.field}>
-                          Tipo de venda
-                          <select
-                            name="unitType"
-                            defaultValue={sku.unitType}
-                            className={styles.control}
-                          >
-                            {unitTypeOptions.map((opt) => (
-                              <option key={opt.value} value={opt.value}>
-                                {opt.label}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                        <input
-                          name="unitLabel"
-                          defaultValue={sku.unitLabel}
-                          placeholder="un/cento/kg/kit"
-                          required
-                          className={styles.control}
-                        />
-                        <label className={styles.field}>
-                          Passo de quantidade
-                          <input
-                            type="number"
-                            name="quantityStep"
-                            step="0.1"
-                            defaultValue={Number(sku.quantityStep)}
-                            required
-                            className={styles.control}
-                          />
-                        </label>
-                        <label className={styles.field}>
-                          Minimo
-                          <input
-                            type="number"
-                            name="minQty"
-                            step="0.1"
-                            defaultValue={Number(sku.minQty)}
-                            required
-                            className={styles.control}
-                          />
-                        </label>
-                        <label className={styles.field}>
-                          Preco atual
-                          <input
-                            type="number"
-                            name="priceCurrent"
-                            step="0.01"
-                            defaultValue={Number(sku.priceCurrent)}
-                            required
-                            className={styles.control}
-                          />
-                        </label>
-                        <label className={styles.field}>
-                          Custo (opcional)
-                          <input
-                            type="number"
-                            name="cost"
-                            step="0.01"
-                            defaultValue={sku.cost ? Number(sku.cost) : ""}
-                            className={styles.control}
-                          />
-                        </label>
-                        <label className={styles.field}>
-                          Tags (separadas por virgula)
-                          <input
-                            name="tags"
-                            defaultValue={sku.tags
-                              .map((tag) => tag.name)
-                              .join(", ")}
-                            className={styles.control}
-                          />
-                        </label>
-                        <label className={styles.field}>
-                          Sob consulta
-                          <select
-                            name="sobConsultaOverride"
-                            defaultValue={
-                              sku.sobConsultaOverride === true
-                                ? "true"
-                                : sku.sobConsultaOverride === false
-                                ? "false"
-                                : "inherit"
-                            }
-                            className={styles.control}
-                          >
-                            <option value="inherit">Herdar do produto</option>
-                            <option value="true">Forcar sob consulta</option>
-                            <option value="false">Forcar nao</option>
-                          </select>
-                        </label>
-                        <label className={styles.choiceRow}>
-                          <input
-                            type="checkbox"
-                            name="isActive"
-                            defaultChecked={sku.isActive}
-                          />
-                          <span className={styles.choiceLabel}>Ativo</span>
-                        </label>
-                        <button
-                          type="submit"
-                          className={`${styles.button} ${styles.buttonSecondary}`}
-                        >
-                          Salvar SKU
-                        </button>
-                      </form>
-                    </td>
-                    <td>{sku.sizeText}</td>
-                    <td>
-                      {sku.unitType} ({sku.unitLabel})
-                    </td>
-                    <td>{sku.isActive ? "ATIVO" : "INATIVO"}</td>
-                    <td>
-                      {sku.sobConsultaOverride === true
-                        ? "SIM"
-                        : sku.sobConsultaOverride === false
-                        ? "NAO"
-                        : product.sobConsulta
-                        ? "SIM"
-                        : "NAO"}
-                    </td>
-                    <td className={styles.tableNumeric}>
-                      R$ {Number(sku.priceCurrent).toFixed(2)}
-                    </td>
-                    <td className={styles.tableActions}>
-                      <form action={duplicateSkuAction}>
-                        <input
-                          type="hidden"
-                          name="productId"
-                          value={product.id}
-                        />
-                        <input type="hidden" name="skuId" value={sku.id} />
-                        <button
-                          type="submit"
-                          className={`${styles.button} ${styles.buttonGhost} ${styles.buttonSm}`}
-                        >
-                          Duplicar
-                        </button>
-                      </form>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </section>
     </main>
   );
 }

--- a/app/admin/products/[id]/productDetail.module.css
+++ b/app/admin/products/[id]/productDetail.module.css
@@ -1,0 +1,93 @@
+.tabs {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.tabList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: var(--space-2);
+}
+
+.tabButton {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-weight: var(--fw-medium);
+  padding: var(--space-2) var(--space-3);
+}
+
+.tabButton:hover,
+.tabButton:focus-visible {
+  color: var(--text-primary);
+  background: var(--bg-subtle);
+}
+
+.tabButtonActive {
+  color: var(--text-primary);
+  background: var(--bg-surface);
+  border-color: var(--border);
+}
+
+.tabPanel {
+  padding-top: var(--space-3);
+}
+
+.skuMeta {
+  display: grid;
+  gap: 2px;
+}
+
+.skuSubline {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-4);
+  z-index: 50;
+}
+
+.modalCard {
+  width: min(860px, 100%);
+  max-height: 90vh;
+  overflow: auto;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-4);
+  display: grid;
+  gap: var(--space-3);
+}
+
+.modalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.modalTitle {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: var(--fw-semibold);
+}
+
+.modalFooter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  justify-content: flex-end;
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-3);
+}


### PR DESCRIPTION
## Summary
- split product detail into tabs and render per-tab content
- add SKU modal and clean SKU table actions
- add separate images form and keep redirects scoped to tab

## Testing
- npm test
- npm run build