### PR TITLE
PR6 — Admin tokens + tipografia + componentes básicos (escopo admin + pedido)

### DIFF
--- a/app/admin/AdminShell.tsx
+++ b/app/admin/AdminShell.tsx
@@ -10,7 +10,7 @@ export default function AdminShell({
   logoutAction: (formData: FormData) => void | Promise<void>;
 }) {
   return (
-    <div className={styles.shell}>
+    <div className={`${styles.shell} ${styles.adminRoot}`}>
       <AdminSidebar logoutAction={logoutAction} />
       <div className={styles.shellMain}>
         <AdminDrawer logoutAction={logoutAction} />

--- a/app/admin/_components/Card.tsx
+++ b/app/admin/_components/Card.tsx
@@ -1,0 +1,23 @@
+import type { ElementType, ComponentPropsWithoutRef, ReactNode } from "react";
+import styles from "../_styles/adminPrimitives.module.css";
+
+type CardProps<T extends ElementType> = {
+  as?: T;
+  children: ReactNode;
+  className?: string;
+} & Omit<ComponentPropsWithoutRef<T>, "as" | "children" | "className">;
+
+export default function Card<T extends ElementType = "div">({
+  as,
+  children,
+  className,
+  ...props
+}: CardProps<T>) {
+  const Component = as ?? "div";
+  const classes = `${styles.panel} ${className || ""}`.trim();
+  return (
+    <Component className={classes} {...props}>
+      {children}
+    </Component>
+  );
+}

--- a/app/admin/_components/EmptyStateCompact.module.css
+++ b/app/admin/_components/EmptyStateCompact.module.css
@@ -1,0 +1,21 @@
+.emptyState {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  padding: var(--space-1) 0;
+}
+
+.icon {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--surface-2);
+  color: var(--text-secondary);
+  font-size: 12px;
+  flex-shrink: 0;
+}

--- a/app/admin/_components/EmptyStateCompact.tsx
+++ b/app/admin/_components/EmptyStateCompact.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+import styles from "./EmptyStateCompact.module.css";
+
+export default function EmptyStateCompact({
+  icon = "OK",
+  children,
+  className,
+}: {
+  icon?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`${styles.emptyState} ${className || ""}`.trim()}>
+      <span className={styles.icon} aria-hidden>
+        {icon}
+      </span>
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/app/admin/_styles/adminPrimitives.module.css
+++ b/app/admin/_styles/adminPrimitives.module.css
@@ -973,6 +973,10 @@
   color: var(--state-error);
 }
 
+.tabularNums {
+  font-variant-numeric: tabular-nums;
+}
+
 /* ===== DEPRECATED: Use Chip component from app/admin/_components/Chip.tsx ===== */
 /* 
  * ⚠️ DEPRECATED: Estas classes são mantidas apenas para compatibilidade durante a migração.

--- a/app/admin/_styles/adminShell.module.css
+++ b/app/admin/_styles/adminShell.module.css
@@ -1,8 +1,57 @@
+.adminRoot {
+  /* ===== ADMIN TOKENS (scoped) ===== */
+  --bg: #F6F7FB;
+  --surface: #FFFFFF;
+  --surface-2: #F3F5F9;
+  --border: #E3E7EF;
+  --divider: #EEF1F6;
+
+  --text-primary: #111827;
+  --text-secondary: #4B5563;
+  --text-muted: #6B7280;
+
+  --shadow-xs: 0 1px 1px rgba(15, 23, 42, 0.04);
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+  --shadow-md: 0 6px 16px rgba(15, 23, 42, 0.10);
+
+  --radius-md: 12px;
+  --radius-lg: 16px;
+
+  --focus-ring: 0 0 0 3px rgba(var(--action-primary-rgb), 0.28);
+  --overlay: rgba(0, 0, 0, 0.35);
+
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-md: 16px;
+  --text-lg: 18px;
+  --text-xl: 20px;
+
+  --fw-regular: 400;
+  --fw-medium: 500;
+  --fw-semibold: 600;
+
+  --lh-tight: 1.2;
+  --lh-normal: 1.5;
+
+  /* ===== Legacy mappings (admin only) ===== */
+  --bg-app: var(--bg);
+  --bg-surface: var(--surface);
+  --bg-subtle: var(--surface-2);
+  --bg-muted: var(--surface-2);
+
+  --border-subtle: var(--divider);
+  --border-strong: #D5DAE3;
+  --border-focus: var(--action-primary);
+
+  --shadow-focus: var(--focus-ring);
+  --text-base: var(--text-md);
+}
+
 .shell {
   min-height: 100vh;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
-  background: var(--bg-app);
+  background: var(--bg);
 }
 
 .shellMain {

--- a/app/admin/orders/[id]/CancelOrderForm.client.tsx
+++ b/app/admin/orders/[id]/CancelOrderForm.client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Button from "../../_components/Button";
 import styles from "../../_styles/adminPrimitives.module.css";
 import { cancelOrderAction } from "./actions";
 
@@ -24,9 +25,9 @@ export default function CancelOrderForm({ orderId }: { orderId: string }) {
         className={styles.control}
         required
       />
-      <button type="submit" className={`${styles.button} ${styles.buttonDanger}`}>
+      <Button type="submit" variant="outline">
         Cancelar pedido
-      </button>
+      </Button>
     </form>
   );
 }

--- a/app/admin/orders/[id]/page.tsx
+++ b/app/admin/orders/[id]/page.tsx
@@ -17,7 +17,10 @@ import OrderDetailFocus from "./OrderDetailFocus.client";
 import OrderDetailPrimaryAction from "./OrderDetailPrimaryAction.client";
 import OrderDetailSidebar from "./OrderDetailSidebar.client";
 import { getOrderDetailViewModel } from "./orderDetailViewModel";
+import Card from "../../_components/Card";
+import Button from "../../_components/Button";
 import Chip from "../../_components/Chip";
+import EmptyStateCompact from "../../_components/EmptyStateCompact";
 import styles from "../../_styles/adminPrimitives.module.css";
 import detailStyles from "../orderDetail.module.css";
 import { InlineNotice } from "../../design-system/InlineNotice.client";
@@ -249,10 +252,12 @@ export default async function OrderDetailPage({
       <div className={styles.pageHeader}>
         <h1 className={styles.pageTitle}>Pedido {order.orderNumber}</h1>
         <div className={styles.clusterSm}>
-          <Link href={editLink} className={styles.button}>
+          <Button href={editLink} variant="outline" size="sm">
             Editar pedido
-          </Link>
-          <Link href="/admin/orders">Voltar</Link>
+          </Button>
+          <Button href="/admin/orders" variant="outline" size="sm">
+            Voltar
+          </Button>
         </div>
       </div>
 
@@ -319,12 +324,12 @@ export default async function OrderDetailPage({
               Ajustar saldo: este pedido foi entregue sem saldo suficiente.
             </div>
             <div className={styles.clusterSm}>
-              <Link href="/admin/producao" className={styles.button}>
+              <Button href="/admin/producao" variant="outline" size="sm">
                 Registrar producao
-              </Link>
-              <Link href="/admin/consumo" className={styles.button}>
+              </Button>
+              <Button href="/admin/consumo" variant="outline" size="sm">
                 Ajustar saldo (admin)
-              </Link>
+              </Button>
             </div>
           </div>
         </div>
@@ -420,7 +425,7 @@ export default async function OrderDetailPage({
           </section>
 
           {showProduction ? (
-            <section id="order-production" className={styles.panel}>
+            <Card as="section" id="order-production">
               <div className={styles.panelHeader}>
                 <h2>
                   {order.orderType === "PRONTA_ENTREGA"
@@ -430,12 +435,9 @@ export default async function OrderDetailPage({
                 {order.orderType === "PRONTA_ENTREGA" && gapItems.length > 0 ? (
                   <form action={convertToEncomendaAction}>
                     <input type="hidden" name="orderId" value={order.id} />
-                    <button
-                      type="submit"
-                      className={`${styles.button} ${styles.buttonSecondary}`}
-                    >
+                    <Button type="submit" variant="secondary" size="sm">
                       Converter para encomenda
-                    </button>
+                    </Button>
                   </form>
                 ) : null}
               </div>
@@ -474,7 +476,7 @@ export default async function OrderDetailPage({
                   })}
                 </div>
               </div>
-            </section>
+            </Card>
           ) : null}
 
           <div className={detailStyles.infoGrid}>
@@ -637,20 +639,16 @@ export default async function OrderDetailPage({
                 {!order.paidAt && (
                   <form action={markPaidAction} style={{ marginTop: "var(--space-3)" }}>
                     <input type="hidden" name="orderId" value={order.id} />
-                    <button
-                      type="submit"
-                      className={`${styles.button} ${styles.buttonPrimary}`}
-                      style={{ width: "100%" }}
-                    >
+                    <Button type="submit" variant="primary" className={detailStyles.fullWidth}>
                       Marcar como pago
-                    </button>
+                    </Button>
                   </form>
                 )}
               </div>
             </section>
           </div>
 
-          <section id="order-items" className={styles.panel}>
+          <Card as="section" id="order-items">
             <div className={styles.panelHeader}>
               <h2>Itens</h2>
             </div>
@@ -673,7 +671,7 @@ export default async function OrderDetailPage({
                           {item.snapshotUnitLabel}
                         </div>
                       </div>
-                      <div>
+                      <div className={styles.tabularNums}>
                         {Number(item.quantity)} {item.snapshotUnitLabel} x{" "}
                         {formatMoney(item.snapshotUnitPrice)} ={" "}
                         {formatMoney(item.lineTotal)}
@@ -688,10 +686,10 @@ export default async function OrderDetailPage({
                 })}
               </div>
             </div>
-          </section>
+          </Card>
 
           {order.needsReconfirmation ? (
-            <section id="order-changes" className={styles.panel}>
+            <Card as="section" id="order-changes">
               <div className={styles.panelHeader}>
                 <h2>Mudancas desde a confirmacao</h2>
               </div>
@@ -713,25 +711,22 @@ export default async function OrderDetailPage({
                 )}
                 <form action={reconfirmOrderAction} className={styles.formSection}>
                   <input type="hidden" name="orderId" value={order.id} />
-                  <button
-                    type="submit"
-                    className={`${styles.button} ${styles.buttonPrimary}`}
-                  >
+                  <Button type="submit" variant="primary">
                     Reconfirmar pedido
-                  </button>
+                  </Button>
                 </form>
               </div>
-            </section>
+            </Card>
           ) : null}
 
           <div id="order-pending" className={detailStyles.twoColumn}>
-            <section className={styles.panel}>
+            <Card as="section">
               <div className={styles.panelHeader}>
                 <h2>Pendencias (bloqueiam)</h2>
               </div>
               <div className={styles.panelBody}>
                 {attention.strongReasons.length === 0 ? (
-                  <div className={styles.emptyState}>Sem pendencias bloqueantes.</div>
+                  <EmptyStateCompact>Sem pendencias bloqueantes.</EmptyStateCompact>
                 ) : (
                   <ul className={detailStyles.summaryList}>
                     {attention.strongReasons.map((reason, index) => {
@@ -760,15 +755,15 @@ export default async function OrderDetailPage({
                   </ul>
                 )}
               </div>
-            </section>
+            </Card>
 
-            <section className={styles.panel}>
+            <Card as="section">
               <div className={styles.panelHeader}>
                 <h2>Alertas (nao bloqueiam)</h2>
               </div>
               <div className={styles.panelBody}>
                 {attention.weakReasons.length === 0 ? (
-                  <div className={styles.emptyState}>Sem alertas.</div>
+                  <EmptyStateCompact>Sem alertas.</EmptyStateCompact>
                 ) : (
                   <ul className={detailStyles.summaryList}>
                     {attention.weakReasons.map((reason, index) => {
@@ -791,10 +786,10 @@ export default async function OrderDetailPage({
                   </ul>
                 )}
               </div>
-            </section>
+            </Card>
           </div>
 
-          <section id="order-actions" className={styles.panel}>
+          <Card as="section" id="order-actions">
             <div className={styles.panelHeader}>
               <h2>Acoes avancadas</h2>
             </div>
@@ -823,23 +818,23 @@ export default async function OrderDetailPage({
                         <span>Marcar pagamento ao entregar</span>
                       </div>
                     </label>
-                    <button
+                    <Button
                       type="submit"
+                      variant="secondary"
                       disabled={
                         order.status === "ENTREGUE" || order.status === "CANCELADO"
                       }
-                      className={`${styles.button} ${styles.buttonSecondary}`}
                     >
                       Atualizar
-                    </button>
+                    </Button>
                   </form>
                   <CancelOrderForm orderId={order.id} />
                 </div>
               </details>
             </div>
-          </section>
+          </Card>
 
-          <section id="order-audit" className={styles.panel}>
+          <Card as="section" id="order-audit">
             <div className={styles.panelHeader}>
               <h2>Auditoria</h2>
             </div>
@@ -872,7 +867,7 @@ export default async function OrderDetailPage({
                 </ul>
               )}
             </div>
-          </section>
+          </Card>
         </div>
 
         <aside className={styles.pageAside}>

--- a/app/admin/orders/orderDetail.module.css
+++ b/app/admin/orders/orderDetail.module.css
@@ -65,6 +65,7 @@
   font-size: var(--text-xl);
   font-weight: var(--fw-semibold);
   color: var(--text-primary);
+  line-height: var(--lh-tight);
 }
 
 .orderHeaderBadges {
@@ -359,12 +360,14 @@
   color: var(--text-primary);
   font-weight: var(--fw-medium);
   text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
 .infoValueLarge {
   font-size: var(--text-lg);
   font-weight: var(--fw-bold);
   color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
 }
 
 /* ===== ORDER HEADER ===== */
@@ -395,6 +398,7 @@
   font-size: var(--text-xl);
   font-weight: var(--fw-bold);
   color: var(--text-primary);
+  line-height: var(--lh-tight);
 }
 
 .orderHeaderMeta {
@@ -459,6 +463,10 @@
 }
 
 .primaryCtaButton {
+  width: 100%;
+}
+
+.fullWidth {
   width: 100%;
 }
 
@@ -655,7 +663,7 @@
 .mobileSheetOverlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.35);
+  background: var(--overlay);
   z-index: 30;
 }
 


### PR DESCRIPTION
## Summary
- add admin-scoped tokens via `AdminShell` scope
- introduce base `Card`/`EmptyStateCompact` components and apply in order detail
- apply typography hierarchy and tabular-nums for monetary values

## Testing
- npm run lint
- npm test
- npm run build *(fails: Prisma EPERM rename on Windows during `prisma generate`)*
